### PR TITLE
qingke_rt::interrupt: Fix string literal creation

### DIFF
--- a/qingke-rt/macros/src/lib.rs
+++ b/qingke-rt/macros/src/lib.rs
@@ -113,7 +113,7 @@ pub fn interrupt(_args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let ident = f.sig.ident.clone();
-    let ident_s = &ident.clone();
+    let ident_s = ident.to_string();
 
     let valid_signature = f.sig.constness.is_none()
         && f.vis == Visibility::Inherited


### PR DESCRIPTION
Test code:

```rust
#[qingke_rt::interrupt]
fn DMA1_CHANNEL2() {}
```

Before this patch, I get this error message:

```
error: attribute value must be a literal
   --> life-module/src/main.rs:196:4
    |
196 | fn DMA1_CHANNEL2() {
    |    ^^^^^^^^^^^^^
```

Output of `cargo expand`:

```rust
#[link_section = ".trap"]
# [export_name = DMA1_CHANNEL2]
#[allow(non_snake_case)]
fn DMA1_CHANNEL2() {}
```

Output of `cargo expand` after this patch (note the conversion to a string literal):

```rust
#[link_section = ".trap"]
#[export_name = "DMA1_CHANNEL2"]
#[allow(non_snake_case)]
fn DMA1_CHANNEL2() {}
```

