### PR TITLE
Add u-mode feature

### DIFF
--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -17,6 +17,8 @@ readme = "README.md"
 v2 = []
 v3 = ["qingke/v3"]
 v4 = []
+
+u-mode = []
 # v5 is not released yet
 # v5 = []
 


### PR DESCRIPTION
Adds a new cargo feature `u-mode` to qingke-rt. This chooses if main is ran at privilege mode M or U. 

This does change the default behaviour to M (cooould change this), but the only thing U-mode would stop is, in main/thread mode only (wouldn't do anything to stop ISRs which always run in M-mode) an M-mode CSR access or M-mode instruction like MRET, but these are unsafe already. Also, Qingke V2 never had U-mode to begin with.

My usecase is for a bootloader where mstatus and MRET are used in order to jump to the application while disabling interrupts sort of like the reset handler does, so it has to run in M-mode.