### PR TITLE
feat: introduce compile error if compiling with atomic on

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Prepare Rust Target
-      run: rustup target add riscv32imac-unknown-none-elf
+      run: rustup target add riscv32imc-unknown-none-elf
     - name: Build
-      run: cargo build --all --target riscv32imac-unknown-none-elf
+      run: cargo build --all --target riscv32imc-unknown-none-elf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/qingke"
 homepage = "https://github.com/ch32-rs/qingke"
 categories = ["embedded", "no-std", "hardware-support"]
 license = "MIT/Apache-2.0"
-version = "0.4.0" # for rt and macros
+version = "0.5.0" # for rt and macros
 edition = "2021"
 
 [package]
@@ -37,6 +37,7 @@ defmt = { version = "0.3.8", optional = true }
 critical-section-impl = ["dep:critical-section"]
 defmt = ["dep:defmt"]
 v3 = []
+unsafe-trust-wch-atomics = []
 
 [package.metadata.docs.rs]
 targets = ["riscv32imac-unknown-none-elf"]

--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -25,8 +25,8 @@ u-mode = []
 highcode = []
 
 [dependencies]
-qingke-rt-macros = { path = "./macros", version = "0.4" }
-qingke = { path = "../", version = "0.4", features = ["critical-section-impl"] }
+qingke-rt-macros = { path = "./macros" }
+qingke = { path = "../", features = ["critical-section-impl"] }
 
 [package.metadata.docs.rs]
 targets = ["riscv32imac-unknown-none-elf"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,22 @@ pub mod register;
 // re-export
 pub use riscv;
 
+#[cfg(all(
+    any(
+        target_has_atomic = "8",
+        // target_has_atomic = "16",
+        // target_has_atomic = "32",
+        // target_has_atomic = "64",
+        // target_has_atomic = "128",
+        // target_has_atomic = "ptr"
+    ),
+    not(feature = "unsafe-trust-wch-atomics")
+))]
+compile_error!(
+    "As tested on QingKe V4, most likely the atomics are broken, 
+please validate the atomic instruction on the hardware using 
+something like litmus test suite before trusting them."
+);
+
 #[cfg(feature = "critical-section-impl")]
 mod critical_section_impl;


### PR DESCRIPTION
This change introduce a compile error if the toolchain is using a target with atomics. It looks like at least on the the QingKe V4 atomics are suspiciously broken.

There is also a feature you can enable `unsafe-trust-wch-atomics` you can enable to remove this compile error

See issue: https://github.com/ch32-rs/ch32-hal/issues/59