### PR TITLE
fix: Patch linker script to mark bss as NOLOAD.

### DIFF
--- a/qingke-rt/link-highcode.x
+++ b/qingke-rt/link-highcode.x
@@ -92,14 +92,14 @@ SECTIONS
         PROVIDE( _edata = .);
     } >RAM AT>FLASH
 
-    .bss : ALIGN(4)
+    .bss (NOLOAD) : ALIGN(4)
     {
         PROVIDE( _sbss = .);
         *(.sbss .sbss.* .bss .bss.*);
         PROVIDE( _ebss = .);
-    } >RAM AT>FLASH
+    } >RAM
 
-    .stack ORIGIN(RAM)+LENGTH(RAM) :
+    .stack ORIGIN(RAM)+LENGTH(RAM) (NOLOAD) :
     {
         . = ALIGN(4);
         PROVIDE(_stack_top = . );

--- a/qingke-rt/link-no-highcode.x
+++ b/qingke-rt/link-no-highcode.x
@@ -77,14 +77,14 @@ SECTIONS
         PROVIDE( _edata = .);
     } >RAM AT>FLASH
 
-    .bss : ALIGN(4)
+    .bss (NOLOAD) : ALIGN(4)
     {
         PROVIDE( _sbss = .);
         *(.sbss .sbss.* .bss .bss.*);
         PROVIDE( _ebss = .);
-    } >RAM AT>FLASH
+    } >RAM
 
-    .stack ORIGIN(RAM)+LENGTH(RAM) :
+    .stack ORIGIN(RAM)+LENGTH(RAM) (NOLOAD) :
     {
         . = ALIGN(4);
         PROVIDE(_stack_top = . );


### PR DESCRIPTION
This is technically a NO-OP patch, I have verified with or without this patch the resulting binary size that actually gets flahsed does not acutally change.

I believe GNU LD actually has special treatment for .bss

Fixes #11