### PR TITLE
fix: use mstatus.MIE for critical_section on qingke_v2

### DIFF
--- a/src/register/gintenr.rs
+++ b/src/register/gintenr.rs
@@ -1,13 +1,18 @@
-//! gintenr, global interrupt enable register
+//! gintenr, global interrupt enable register (CSR 0x800)
 //!
 //! This is a mapping to mie & mpie
 //!
 //! 全局中断使能寄存器
 //!
 //! Write 0x08 to enable global interrupt
+//!
+//! NOTE: This register is NOT available on qingke_v2 (CH32V003).
+//! Use mstatus.MIE instead for qingke_v2.
 
+#[cfg(not(qingke_v2))]
 use core::arch::asm;
 
+#[cfg(not(qingke_v2))]
 #[inline]
 pub fn read() -> usize {
     let ans: usize;
@@ -15,17 +20,20 @@ pub fn read() -> usize {
     ans
 }
 
+#[cfg(not(qingke_v2))]
 #[inline]
 pub unsafe fn write(bits: usize) {
     asm!("csrw 0x800, {}", in(reg) bits);
 }
 
+#[cfg(not(qingke_v2))]
 #[inline]
 pub unsafe fn set_enable() {
     let mask = 0x8;
     asm!("csrs 0x800, {}", in(reg) mask);
 }
 
+#[cfg(not(qingke_v2))]
 #[inline]
 /// Disable interrupt and return the old `GINTENR` value
 pub fn set_disable() -> usize {


### PR DESCRIPTION
CH32V003 (qingke_v2) does not have gintenr register (CSR 0x800). Use standard RISC-V mstatus.MIE instead for critical section implementation.

Also add #[cfg(not(qingke_v2))] to gintenr module to prevent misuse.

Fixes #15