### PR TITLE
Fix interrupt table lookup for chain-loaded apps

### DIFF
--- a/qingke-rt/assert-v2-align-highcode.x
+++ b/qingke-rt/assert-v2-align-highcode.x
@@ -1,0 +1,1 @@
+ASSERT(_highcode_vma_start % 1024 == 0, "vector table must be 1KB aligned for Qingke V2");

--- a/qingke-rt/assert-v2-align-no-highcode.x
+++ b/qingke-rt/assert-v2-align-no-highcode.x
@@ -1,0 +1,1 @@
+ASSERT(_start % 1024 == 0, "vector table must be 1KB aligned for Qingke V2");

--- a/qingke-rt/build.rs
+++ b/qingke-rt/build.rs
@@ -67,10 +67,21 @@ fn main() {
         fs::write(out_dir.join("link.x"), include_bytes!("link-no-highcode.x")).unwrap();
     }
 
+    // V2 requires the vector table to be 1KB-aligned
+    let has_v2 = env::var("CARGO_FEATURE_V2").is_ok();
+    let asserts: &[u8] = match (has_v2, has_highcode_feature) {
+        (true, true) => include_bytes!("assert-v2-align-highcode.x"),
+        (true, false) => include_bytes!("assert-v2-align-no-highcode.x"),
+        _ => b"",
+    };
+    fs::write(out_dir.join("assert-align.x"), asserts).unwrap();
+
     println!("cargo:rustc-link-search={}", out_dir.display());
 
     println!("cargo:rerun-if-changed=link-highcode.x");
     println!("cargo:rerun-if-changed=link-no-highcode.x");
+    println!("cargo:rerun-if-changed=assert-v2-align-highcode.x");
+    println!("cargo:rerun-if-changed=assert-v2-align-no-highcode.x");
     println!("cargo:rerun-if-changed=build.rs");
 
     let target = env::var("TARGET").unwrap();

--- a/qingke-rt/link-highcode.x
+++ b/qingke-rt/link-highcode.x
@@ -49,12 +49,12 @@ SECTIONS
         . = ALIGN(4);
     } >FLASH AT>FLASH
 
-    /* highcode section will be copied to RAM offset 0x0 */
+    /* highcode section will be copied to RAM */
     .highcode : ALIGN(4)
     {
         _highcode_lma = LOADADDR(.highcode);
         PROVIDE(_highcode_vma_start = .);
-        LONG(0x00000000); /* Placeholder for the first vector */
+        LONG(_start); /* Placeholder for the first vector */
         KEEP(*(.vector_table.core_interrupts));
         KEEP(*(.vector_table.external_interrupts));
         KEEP(*(.vector_table.exceptions));

--- a/qingke-rt/link-highcode.x
+++ b/qingke-rt/link-highcode.x
@@ -118,3 +118,5 @@ SECTIONS
     .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
     .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
+
+ASSERT(_highcode_vma_start % 1024 == 0, "vector table must be 1KB aligned for Qingke V2");

--- a/qingke-rt/link-highcode.x
+++ b/qingke-rt/link-highcode.x
@@ -119,4 +119,4 @@ SECTIONS
     .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
 
-ASSERT(_highcode_vma_start % 1024 == 0, "vector table must be 1KB aligned for Qingke V2");
+INCLUDE assert-align.x

--- a/qingke-rt/link-no-highcode.x
+++ b/qingke-rt/link-no-highcode.x
@@ -103,3 +103,5 @@ SECTIONS
     .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
     .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
+
+ASSERT(_start % 1024 == 0, "vector table must be 1KB aligned for Qingke V2");

--- a/qingke-rt/link-no-highcode.x
+++ b/qingke-rt/link-no-highcode.x
@@ -104,4 +104,4 @@ SECTIONS
     .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
 
-ASSERT(_start % 1024 == 0, "vector table must be 1KB aligned for Qingke V2");
+INCLUDE assert-align.x

--- a/qingke-rt/src/lib.rs
+++ b/qingke-rt/src/lib.rs
@@ -209,10 +209,22 @@ unsafe extern "C" fn qingke_setup_interrupts() {
     #[cfg(not(feature = "v3a"))]
     unsafe {
         #[cfg(feature = "highcode")]
-        mtvec::write(0x20000000, TrapMode::VectoredAddress);
-
+        {
+            unsafe extern "C" {
+                static _highcode_vma_start: u8;
+            }
+            mtvec::write(
+                &raw const _highcode_vma_start as usize,
+                TrapMode::VectoredAddress,
+            );
+        }
         #[cfg(not(feature = "highcode"))]
-        mtvec::write(0x00000000, TrapMode::VectoredAddress);
+        {
+            unsafe extern "C" {
+                static _start: u8;
+            }
+            mtvec::write(&raw const _start as usize, TrapMode::VectoredAddress);
+        }
     }
 
     unsafe {


### PR DESCRIPTION
## Issue Description

I have a bootloader ([`tinyboot`](https://github.com/OpenServoCore/tinyboot)) at the start of FLASH on a CH32V006, and the application loads behind it. Every interrupt was crashing the application.

Here is an example `memory.x`:

```ld
/* 8 KB bootloader at the start of flash */
MEMORY
{
    FLASH : ORIGIN = 0x00002000, LENGTH = 54K
    RAM   : ORIGIN = 0x20000000, LENGTH = 8K
}
```

The application's vector table ends up at `0x00002000`. But `qingke_setup_interrupts` writes a hardcoded `mtvec`:

```rust
mtvec::write(0x00000000, TrapMode::VectoredAddress);   // no-highcode
mtvec::write(0x20000000, TrapMode::VectoredAddress);   // highcode
```

Those constants assume the program lives at the very start of FLASH and SRAM. For me, `mtvec = 0x00000000` points back into the bootloader, not at my vector table — so when an interrupt fires, the CPU dispatches into bootloader memory and the app crashes. Same problem hits any chain-loaded scenario (custom bootloaders, OTA loaders, [`embassy-boot`](https://github.com/embassy-rs/embassy/tree/main/embassy-boot) on `qingke-rt` if anyone uses that combo — I haven't tried it).

## The Fix

Use the linker symbols `_start` and `_highcode_vma_start` instead of hardcoded constants:

```rust
// no-highcode
mtvec::write(&raw const _start as usize, TrapMode::VectoredAddress);

// highcode
mtvec::write(&raw const _highcode_vma_start as usize, TrapMode::VectoredAddress);
```

Both symbols are already defined by the linker scripts and evaluate to wherever the linker actually placed the vector table. For the default `memory.x` (FLASH at `0x00000000`, RAM at `0x20000000`) they evaluate to exactly the old hardcoded values, and shouldn't impact anyone. For chain-loaded apps, `mtvec` now correctly tracks the application's offset.

p.s. this PR also allows highcode to work with non-standard starting address. This is handy for e.g. a bootloader handoff region in SRAM. 