### PR TITLE
fix: missing `.uninit (NOLOAD)` section causes ~500MB binary output with wlink

### DIFF
--- a/qingke-rt/link-highcode.x
+++ b/qingke-rt/link-highcode.x
@@ -99,6 +99,11 @@ SECTIONS
         PROVIDE( _ebss = .);
     } >RAM
 
+    .uninit (NOLOAD) : ALIGN(4)
+    {
+        *(.uninit .uninit.*);
+    } >RAM
+
     .stack ORIGIN(RAM)+LENGTH(RAM) (NOLOAD) :
     {
         . = ALIGN(4);

--- a/qingke-rt/link-no-highcode.x
+++ b/qingke-rt/link-no-highcode.x
@@ -84,6 +84,11 @@ SECTIONS
         PROVIDE( _ebss = .);
     } >RAM
 
+    .uninit (NOLOAD) : ALIGN(4)
+    {
+        *(.uninit .uninit.*);
+    } >RAM
+
     .stack ORIGIN(RAM)+LENGTH(RAM) (NOLOAD) :
     {
         . = ALIGN(4);


### PR DESCRIPTION
When I used `defmt-rtt` with `qingke-rt` and flash with `wlink`, it produces a ~500MB binary that failed to flash.

Turns out `defmt-rtt` places its RTT buffer in `.uninit.*` sections and expects them to be NOLOAD. Since `qingke-rt`'s linker scripts don't define a `.uninit` section, the linker places these symbols in a default loadable segment with a RAM VMA (0x20000000+). `wlink` interprets the RAM VMA as a flash offset, so the output binary spans from 0x00000000 to 0x20000xxx.

This PR adds a `.uninit (NOLOAD)` section after `.bss` in both `link-highcode.x` and `link-no-highcode.x`, matching [what `cortex-m-rt` does](https://github.com/rust-embedded/cortex-m/blob/master/cortex-m-rt/link.x.in#L175-L183).