### PR TITLE
chore: sync main with crates.io 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/qingke"
 homepage = "https://github.com/ch32-rs/qingke"
 categories = ["embedded", "no-std", "hardware-support"]
 license = "MIT/Apache-2.0"
-version = "0.6.0" # for rt and macros
+version = "0.6.1" # for rt and macros
 edition = "2024"
 
 [package]

--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -25,8 +25,8 @@ u-mode = []
 highcode = []
 
 [dependencies]
-qingke-rt-macros = {  version = "0.6.0", path = "./macros" }
-qingke = { version = "0.6.0", path = "../", features = ["critical-section-impl"] }
+qingke-rt-macros = {  version = "0.6.1", path = "./macros" }
+qingke = { version = "0.6.1", path = "../", features = ["critical-section-impl"] }
 
 [package.metadata.docs.rs]
 targets = ["riscv32imc-unknown-none-elf"]

--- a/qingke-rt/macros/src/lib.rs
+++ b/qingke-rt/macros/src/lib.rs
@@ -60,7 +60,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
 
     quote!(
         #[allow(non_snake_case)]
-        #[export_name = "main"]
+        #[unsafe(export_name = "main")]
         #(#attrs)*
         pub #unsafety fn __risc_v_rt__main(#args) -> ! {
             #(#stmts)*
@@ -89,7 +89,7 @@ pub fn highcode(_args: TokenStream, input: TokenStream) -> TokenStream {
     let f = parse_macro_input!(input as ItemFn);
 
     let section = quote! {
-        #[link_section = ".highcode"]
+        #[unsafe(link_section = ".highcode")]
         #[inline(never)] // make certain function is not inlined
     };
 
@@ -245,8 +245,8 @@ core::arch::global_asm!(
         #start_interrupt_asm
 
         #[allow(non_snake_case)]
-        #[no_mangle]
-        #[link_section = ".trap.rust"]
+        #[unsafe(no_mangle)]
+        #[unsafe(link_section = ".trap.rust")]
         #f
     )
     .into()


### PR DESCRIPTION
This PR resolves Issue #18 .

 I copied over all the changes from the crates.io version 0.6.1 tarball:

- Bump version sto 0.6.1
- use `#[unsafe(...)]` attributes (Rust 2024 edition)

Verified by diffing `src/` directories against the crates.io tarball, so I'm pretty sure I didn't miss anything, but if I did feel free to let me know and I'd be happy to update it. Thanks!