### PR TITLE
Fix Interrupt Handling and Critical Section for V3A based chips (CH32V103, CH565, CH569, CH571, CH573)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ critical-section-impl = ["dep:critical-section"]
 defmt = ["dep:defmt"]
 v2 = []
 v3 = []
+v3a = ["v3"]
 v4 = []
 unsafe-trust-wch-atomics = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,9 @@ defmt = { version = "1.0.1", optional = true }
 critical-section-impl = ["dep:critical-section"]
 defmt = ["dep:defmt"]
 v2 = []
-v3 = []
-v3a = ["v3"]
+_v3 = []
+v3a = ["_v3"]
+v3b = ["_v3"]
 v4 = []
 unsafe-trust-wch-atomics = []
 

--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 [features]
 v2 = ["qingke/v2"]
 v3 = ["qingke/v3"]
+v3a = ["qingke/v3a", "v3"]
 v4 = ["qingke/v4"]
 
 u-mode = []

--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -15,8 +15,9 @@ readme = "README.md"
 
 [features]
 v2 = ["qingke/v2"]
-v3 = ["qingke/v3"]
-v3a = ["qingke/v3a", "v3"]
+_v3 = []
+v3a = ["qingke/v3a", "_v3"]
+v3b = ["qingke/v3b", "_v3"]
 v4 = ["qingke/v4"]
 
 u-mode = []

--- a/qingke-rt/src/lib.rs
+++ b/qingke-rt/src/lib.rs
@@ -144,7 +144,7 @@ unsafe extern "C" fn qingke_setup_interrupts() {
         );
     }
 
-    // Qingke V3A
+    // Qingke V3A, V3B, V3C, V3F, V3V
     #[cfg(feature = "v3")]
     unsafe {
         #[cfg(feature = "u-mode")]
@@ -195,15 +195,27 @@ unsafe extern "C" fn qingke_setup_interrupts() {
         qingke::register::gintenr::set_enable();
     }
 
+    // V3A: no VectoredAddress support, use Direct mode + software dispatch.
+    #[cfg(feature = "v3a")]
+    unsafe {
+        unsafe extern "C" {
+            fn _unified_trap_handler();
+        }
+        mtvec::write(_unified_trap_handler as *const () as usize, TrapMode::Direct);
+    }
+
     // Qingke V2's mtvec must be 1KB aligned.
 
+    #[cfg(not(feature = "v3a"))]
     unsafe {
         #[cfg(feature = "highcode")]
         mtvec::write(0x20000000, TrapMode::VectoredAddress);
 
         #[cfg(not(feature = "highcode"))]
         mtvec::write(0x00000000, TrapMode::VectoredAddress);
+    }
 
+    unsafe {
         qingke::pfic::wfi_to_wfe(true);
     }
 }
@@ -242,6 +254,53 @@ global_asm!(
         lw ra, 0(sp)
         addi sp, sp, 4
         mret
+    "#
+);
+
+// V3A software dispatch handler for Direct mode.
+// Reads mcause, looks up handler address from the vector table, and jumps to it.
+#[cfg(all(feature = "v3a", feature = "highcode"))]
+global_asm!(
+    r#"
+        .section .trap, "ax"
+        .global _unified_trap_handler
+        .align 2
+    _unified_trap_handler:
+        csrr t0, mcause
+        bgez t0, _exception_handler
+        slli t0, t0, 1
+        srli t0, t0, 1
+        slli t0, t0, 2
+        la t1, _highcode_vma_start
+        add t0, t0, t1
+        lw t0, 0(t0)
+        beqz t0, 1f
+        jr t0
+    1:
+        la t0, DefaultInterruptHandler
+        jr t0
+    "#
+);
+
+#[cfg(all(feature = "v3a", not(feature = "highcode")))]
+global_asm!(
+    r#"
+        .section .trap, "ax"
+        .global _unified_trap_handler
+        .align 2
+    _unified_trap_handler:
+        csrr t0, mcause
+        bgez t0, _exception_handler
+        slli t0, t0, 1
+        srli t0, t0, 1
+        slli t0, t0, 2
+        la t1, _start
+        add t0, t0, t1
+        lw t0, 0(t0)
+        beqz t0, 1f
+        jr t0
+    1:
+        j DefaultInterruptHandler
     "#
 );
 

--- a/qingke-rt/src/lib.rs
+++ b/qingke-rt/src/lib.rs
@@ -145,7 +145,7 @@ unsafe extern "C" fn qingke_setup_interrupts() {
     }
 
     // Qingke V3A, V3B, V3C, V3F, V3V
-    #[cfg(feature = "v3")]
+    #[cfg(feature = "_v3")]
     unsafe {
         #[cfg(feature = "u-mode")]
         core::arch::asm!(
@@ -167,7 +167,7 @@ unsafe extern "C" fn qingke_setup_interrupts() {
     // corecfgr(0xbc0): Pipeline control bit & Dynamic prediction control
     #[cfg(any(
         feature = "v4",
-        not(any(feature = "v2", feature = "v3", feature = "v4"))     // Fallback condition
+        not(any(feature = "v2", feature = "_v3", feature = "v4"))     // Fallback condition
     ))]
     unsafe {
         #[cfg(feature = "u-mode")]

--- a/src/critical_section_impl.rs
+++ b/src/critical_section_impl.rs
@@ -6,8 +6,9 @@ set_impl!(SingleHartCriticalSection);
 unsafe impl Impl for SingleHartCriticalSection {
     unsafe fn acquire() -> RawRestoreState {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "v2")] {
+            if #[cfg(any(feature = "v2", feature = "v3a"))] {
                 // CH32V003 (qingke_v2) does not have gintenr register
+                // v3a has "invalid" gintenr register - according to QingKeV3_Processor_Manual.pdf page 26
                 // Use standard RISC-V mstatus.MIE instead
                 let mut mstatus: usize;
                 unsafe { core::arch::asm!("csrrci {}, mstatus, 0b1000", out(reg) mstatus) };
@@ -24,7 +25,7 @@ unsafe impl Impl for SingleHartCriticalSection {
         // Only re-enable interrupts if they were enabled before the critical section.
         if irq_state {
             cfg_if::cfg_if! {
-                if #[cfg(feature = "v2")] {
+                if #[cfg(any(feature = "v2", feature = "v3a"))] {
                     unsafe { core::arch::asm!("csrsi mstatus, 0b1000") };
                 } else {
                     use crate::register::gintenr;

--- a/src/pfic.rs
+++ b/src/pfic.rs
@@ -121,7 +121,7 @@ pub fn get_priority(irq: u8) -> u8 {
 }
 
 /// Enable VTF0, VTFBADDRR will be overwritten
-#[cfg(feature = "v3")]
+#[cfg(feature = "_v3")]
 pub unsafe fn enable_vtf(channel: u8, irq: u8, address: u32) {
     assert!(channel < 4, "VTF channel must be less than 4");
     const PFIC_VTFBADDRR: *mut u32 = 0xE000E044 as *mut u32;
@@ -136,14 +136,14 @@ pub unsafe fn enable_vtf(channel: u8, irq: u8, address: u32) {
     }
 }
 
-#[cfg(feature = "v3")]
+#[cfg(feature = "_v3")]
 pub unsafe fn disable_vtf(channel: u8) {
     assert!(channel < 4, "VTF channel must be less than 4");
     let val = ptr::read_volatile(PFIC_VTFADDRR0.offset(channel as isize));
     ptr::write_volatile(PFIC_VTFADDRR0.offset(channel as isize), val & 0x00FF_FFFF);
 }
 
-#[cfg(not(feature = "v3"))]
+#[cfg(not(feature = "_v3"))]
 pub unsafe fn enable_vtf(channel: u8, irq: u8, address: u32) {
     assert!(channel < 4, "VTF channel must be less than 4");
 
@@ -163,7 +163,7 @@ pub unsafe fn enable_vtf(channel: u8, irq: u8, address: u32) {
     }
 }
 
-#[cfg(not(feature = "v3"))]
+#[cfg(not(feature = "_v3"))]
 pub unsafe fn disable_vtf(channel: u8) {
     assert!(channel < 4, "VTF channel must be less than 4");
     unsafe {


### PR DESCRIPTION
## Problem

When I was working with CH32V103, any Interrupt or Critical Section usage cause the chip to hang. I was able to trace the problem to how V3A is different than other V3 chips in two ways:

1. V3A has no VectoredAddress support for interrupt handling.
2. V3A has "invalid" `gintenr` register. ( Documented in the reference manual )

## Fix

### Interrupt Handling

In this PR, I opted to use `Direct` trap mode, because `VectoredJump` trap mode would require generating a jump instruction based vector table instead of the current address based vector table.

Anyways, the solution in the PR hooks the `mtvec` address to a `_unified_trap_handler`. This handler then  reads `mcause`, looks up handler address from the address based vector table, and jumps to it. Both `highcode` and non-`highcode` cases are covered. 

### Critical Section

The reference manual says `gintenr` is invalid for V3A, so this PR uses `mstatus` instead, the same way as V2.

