### PR TITLE
feat: V3F/V5F (CH32H4) dual-core support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ v2 = []
 _v3 = []
 v3a = ["_v3"]
 v3b = ["_v3"]
+v3f = ["_v3"]
 v4 = []
 unsafe-trust-wch-atomics = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,16 @@ v2 = []
 _v3 = []
 v3a = ["_v3"]
 v3b = ["_v3"]
-v3f = ["_v3"]
+v3f = ["_v3", "_inestcr"]
 v4 = []
-_v5 = []
+_v5 = ["_inestcr"]
 v5f = ["_v5"]
+# CSR 0xBC1 (inestcr / interrupt nest control) is V5-only in the
+# generic QingKe IP family; it is also wired up on the CH32H417 V3F
+# extension. V2 / V3A / V3B / V4 raise an illegal-instruction trap
+# when 0xBC1 is accessed, so the register module is gated behind
+# this umbrella feature.
+_inestcr = []
 # Multi-core PFIC extensions (HartId, wake_other_core).
 # Only meaningful on chips whose PFIC implements HART_ID and WAKEIP0/1,
 # currently CH32H417 (V3F + V5F). Writing WAKEIP0/1 on chips without

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ v3f = ["_v3"]
 v4 = []
 _v5 = []
 v5f = ["_v5"]
+# Multi-core PFIC extensions (HartId, wake_other_core).
+# Only meaningful on chips whose PFIC implements HART_ID and WAKEIP0/1,
+# currently CH32H417 (V3F + V5F). Writing WAKEIP0/1 on chips without
+# them is undefined behavior, hence the opt-in gate.
+dual-core = []
 unsafe-trust-wch-atomics = []
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ v3a = ["_v3"]
 v3b = ["_v3"]
 v3f = ["_v3"]
 v4 = []
+_v5 = []
+v5f = ["_v5"]
 unsafe-trust-wch-atomics = []
 
 [package.metadata.docs.rs]

--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -18,6 +18,7 @@ v2 = ["qingke/v2"]
 _v3 = []
 v3a = ["qingke/v3a", "_v3"]
 v3b = ["qingke/v3b", "_v3"]
+v3f = ["qingke/v3f", "_v3"]
 v4 = ["qingke/v4"]
 
 u-mode = []

--- a/qingke-rt/Cargo.toml
+++ b/qingke-rt/Cargo.toml
@@ -20,10 +20,10 @@ v3a = ["qingke/v3a", "_v3"]
 v3b = ["qingke/v3b", "_v3"]
 v3f = ["qingke/v3f", "_v3"]
 v4 = ["qingke/v4"]
+_v5 = []
+v5f = ["qingke/v5f", "_v5"]
 
 u-mode = []
-# v5 is not released yet
-# v5 = []
 
 highcode = []
 

--- a/qingke-rt/src/lib.rs
+++ b/qingke-rt/src/lib.rs
@@ -168,9 +168,9 @@ unsafe extern "C" fn qingke_setup_interrupts() {
     // Qingke V3F (CH32H417 primary core).
     // Unlike V3A/V3B, V3F's WCH startup writes the full set of QingKe
     // control CSRs: pipeline/branch-prediction config (corecfgr 0xBC0),
-    // 2-level nest control (0xBC1), interrupt nesting + hardware-stack
-    // enable (intsyscr 0x804), and a full `csrw` of mstatus selecting
-    // U-mode return + FP-Dirty. Values mirror
+    // 2-level nest control (inestcr 0xBC1), interrupt nesting +
+    // hardware-stack enable (intsyscr 0x804), and a full `csrw` of
+    // mstatus selecting U-mode return + FP-Dirty. Values mirror
     // `startup_ch32h417_v3f.S:541-551`.
     //
     // Note: the post-block FP-enable code below (`#[cfg(any(riscvf,
@@ -179,12 +179,12 @@ unsafe extern "C" fn qingke_setup_interrupts() {
     // Dirty automatically.
     #[cfg(feature = "v3f")]
     unsafe {
+        use qingke::register::inestcr::{self, NestLevel};
+        inestcr::write(NestLevel::Two as usize);
         core::arch::asm!(
             "
             li t0, 0x123703E1
             csrw 0xBC0, t0
-            li t0, 0x01
-            csrw 0xBC1, t0
             li t0, 0x07
             csrw 0x804, t0
             li t0, 0x6088
@@ -209,12 +209,12 @@ unsafe extern "C" fn qingke_setup_interrupts() {
     // will reset FS from Dirty to Initial.
     #[cfg(feature = "v5f")]
     unsafe {
+        use qingke::register::inestcr::{self, NestLevel};
+        inestcr::write(NestLevel::Eight as usize);
         core::arch::asm!(
             "
             li t0, 0x1237B3E0
             csrw 0xBC0, t0
-            li t0, 0x07
-            csrw 0xBC1, t0
             li t0, 0x0F
             csrw 0x804, t0
             li t0, 0x6088

--- a/qingke-rt/src/lib.rs
+++ b/qingke-rt/src/lib.rs
@@ -193,11 +193,41 @@ unsafe extern "C" fn qingke_setup_interrupts() {
         );
     }
 
+    // Qingke V5F (CH32H417 secondary core).
+    // V5F is a deeper / wider core than V3F: 8-level interrupt nesting
+    // (vs V3F's 2), pmtcfg=11 in intsyscr (vs V3F's 01), and extra
+    // pipeline tuning bits in corecfgr (NLP_EN + a couple of reserved
+    // defaults). Values mirror `startup_ch32h417_v5f.S:481-491`.
+    //
+    // Note: ICache and PMP setup that the WCH SDK does immediately
+    // after this block (using `_cache_beg` / `_cache_end` linker
+    // symbols) is intentionally NOT performed here — it requires the
+    // user's linker script to define those symbols. ICache support
+    // will land as a separate opt-in feature.
+    //
+    // Same FS-downgrade note as v3f applies: the riscvf/d post-block
+    // will reset FS from Dirty to Initial.
+    #[cfg(feature = "v5f")]
+    unsafe {
+        core::arch::asm!(
+            "
+            li t0, 0x1237B3E0
+            csrw 0xBC0, t0
+            li t0, 0x07
+            csrw 0xBC1, t0
+            li t0, 0x0F
+            csrw 0x804, t0
+            li t0, 0x6088
+            csrw mstatus, t0
+            "
+        );
+    }
+
     // corecfgr(0xbc0): 流水线控制位 & 动态预测控制位
     // corecfgr(0xbc0): Pipeline control bit & Dynamic prediction control
     #[cfg(any(
         feature = "v4",
-        not(any(feature = "v2", feature = "_v3", feature = "v4"))     // Fallback condition
+        not(any(feature = "v2", feature = "_v3", feature = "_v5", feature = "v4"))     // Fallback condition
     ))]
     unsafe {
         #[cfg(feature = "u-mode")]

--- a/qingke-rt/src/lib.rs
+++ b/qingke-rt/src/lib.rs
@@ -144,8 +144,10 @@ unsafe extern "C" fn qingke_setup_interrupts() {
         );
     }
 
-    // Qingke V3A, V3B, V3C, V3F, V3V
-    #[cfg(feature = "_v3")]
+    // Qingke V3A, V3B, V3C, V3V (non-V3F V3 variants).
+    // Leaves corecfgr / intsyscr / nest-level at reset defaults; only
+    // OR's a couple of bits into mstatus.
+    #[cfg(all(feature = "_v3", not(feature = "v3f")))]
     unsafe {
         #[cfg(feature = "u-mode")]
         core::arch::asm!(
@@ -159,6 +161,34 @@ unsafe extern "C" fn qingke_setup_interrupts() {
             "
             li t0, 0x1880
             csrs mstatus, t0
+            "
+        );
+    }
+
+    // Qingke V3F (CH32H417 primary core).
+    // Unlike V3A/V3B, V3F's WCH startup writes the full set of QingKe
+    // control CSRs: pipeline/branch-prediction config (corecfgr 0xBC0),
+    // 2-level nest control (0xBC1), interrupt nesting + hardware-stack
+    // enable (intsyscr 0x804), and a full `csrw` of mstatus selecting
+    // U-mode return + FP-Dirty. Values mirror
+    // `startup_ch32h417_v3f.S:541-551`.
+    //
+    // Note: the post-block FP-enable code below (`#[cfg(any(riscvf,
+    // riscvd))]`) will subsequently downgrade FS from Dirty (0b11) to
+    // Initial (0b01); the first FP register write bumps it back to
+    // Dirty automatically.
+    #[cfg(feature = "v3f")]
+    unsafe {
+        core::arch::asm!(
+            "
+            li t0, 0x123703E1
+            csrw 0xBC0, t0
+            li t0, 0x01
+            csrw 0xBC1, t0
+            li t0, 0x07
+            csrw 0x804, t0
+            li t0, 0x6088
+            csrw mstatus, t0
             "
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,23 @@ pub mod register;
 // re-export
 pub use riscv;
 
+// Core family selection is mutually exclusive — picking more than one
+// means downstream asm blocks (e.g. `qingke_setup_interrupts`) emit
+// conflicting startup sequences and the second one clobbers the first.
+#[cfg(any(
+    all(feature = "v2", feature = "_v3"),
+    all(feature = "v2", feature = "v4"),
+    all(feature = "v2", feature = "_v5"),
+    all(feature = "_v3", feature = "v4"),
+    all(feature = "_v3", feature = "_v5"),
+    all(feature = "v4", feature = "_v5"),
+))]
+compile_error!(
+    "qingke: at most one core-family feature (v2 / _v3 / v4 / _v5) may be enabled. \
+     Concrete leaves like v3a/v3b/v3f/v5f pull in their umbrella, so e.g. v3f and v5f \
+     conflict because v3f → _v3 and v5f → _v5."
+);
+
 #[cfg(all(
     any(
         target_has_atomic = "8",

--- a/src/pfic.rs
+++ b/src/pfic.rs
@@ -153,8 +153,10 @@ pub unsafe fn enable_vtf(channel: u8, irq: u8, address: u32) {
 #[cfg(feature = "_v3")]
 pub unsafe fn disable_vtf(channel: u8) {
     assert!(channel < 4, "VTF channel must be less than 4");
-    let val = ptr::read_volatile(PFIC_VTFADDRR0.offset(channel as isize));
-    ptr::write_volatile(PFIC_VTFADDRR0.offset(channel as isize), val & 0x00FF_FFFF);
+    unsafe {
+        let val = ptr::read_volatile(PFIC_VTFADDRR0.offset(channel as isize));
+        ptr::write_volatile(PFIC_VTFADDRR0.offset(channel as isize), val & 0x00FF_FFFF);
+    }
 }
 
 #[cfg(not(feature = "_v3"))]

--- a/src/pfic.rs
+++ b/src/pfic.rs
@@ -48,6 +48,13 @@ const PFIC_IPRIOR0: *mut u8 = 0xE000E400 as *mut u8;
 /// 系统控制寄存器
 const PFIC_SCTLR: *mut u32 = 0xE000ED10 as *mut u32;
 
+/// Wake-up instruction pointer register for hart 0 (C0)
+/// 内核 C0 唤醒指令指针寄存器
+const PFIC_WAKEIP0: *mut u32 = 0xE000E720 as *mut u32;
+/// Wake-up instruction pointer register for hart 1 (C1)
+/// 内核 C1 唤醒指令指针寄存器
+const PFIC_WAKEIP1: *mut u32 = 0xE000E724 as *mut u32;
+
 #[inline]
 pub unsafe fn enable_interrupt(irq: u8) {
     let offset = (irq / 32) as isize;
@@ -184,4 +191,84 @@ pub unsafe fn wfi_to_wfe(v: bool) {
         }
         ptr::write_volatile(PFIC_SCTLR, val);
     });
+}
+
+/// Identifies the current QingKe hart in a multi-core PFIC.
+///
+/// Read from `PFIC_SCTLR[23:16]` (HART_ID field). Only the LSB is
+/// meaningful — the upper bits of that field are reserved.
+///
+/// On single-core chips this always reads as [`HartId::C0`]. On
+/// dual-core chips such as CH32H417, the primary boot core (V3F) is
+/// `C0` and the secondary core (V5F) is `C1`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum HartId {
+    /// Core 0 (V3F on CH32H417)
+    C0 = 0,
+    /// Core 1 (V5F on CH32H417)
+    C1 = 1,
+}
+
+impl HartId {
+    /// Read the current hart ID from `PFIC_SCTLR`.
+    #[inline]
+    pub fn current() -> Self {
+        let sctlr = unsafe { ptr::read_volatile(PFIC_SCTLR) };
+        if (sctlr & (1 << 16)) != 0 {
+            HartId::C1
+        } else {
+            HartId::C0
+        }
+    }
+
+    /// Return the *other* hart's ID.
+    #[inline]
+    pub const fn other(self) -> Self {
+        match self {
+            HartId::C0 => HartId::C1,
+            HartId::C1 => HartId::C0,
+        }
+    }
+
+    /// 0 or 1, suitable for indexing per-hart resources.
+    #[inline]
+    pub const fn to_index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Wake the *other* hart from its deep-sleep lock and set its entry PC
+/// to `entry`.
+///
+/// Rust equivalent of WCH SDK's `NVIC_WakeUp_V3F` / `NVIC_WakeUp_V5F`.
+/// It writes `entry` into the other hart's `PFIC_WAKEIPx` register —
+/// because `entry` is required to be 1KB-aligned, the write also
+/// clears the `SHUTDOWN_x` bit (bit 0), releasing the hart from its
+/// deep-sleep lock — then sets `PFIC_SCTLR.SENDEVENT` (bit 5) to
+/// deliver the wake event.
+///
+/// On single-core chips this writes to a reserved register and has no
+/// observable effect.
+///
+/// # Safety
+/// - `entry` must be 1KB-aligned (bottom 10 bits zero); debug builds
+///   panic otherwise.
+/// - The image at `entry` must already be programmed in Flash and be
+///   reachable from the other hart's address space.
+/// - Typically called once by the primary hart (`C0`) during boot,
+///   before any cross-core synchronization protocol begins.
+#[inline]
+pub unsafe fn wake_other_core(entry: u32) {
+    debug_assert!(entry & 0x3FF == 0, "entry must be 1KB-aligned");
+    let wakeip = match HartId::current().other() {
+        HartId::C0 => PFIC_WAKEIP0,
+        HartId::C1 => PFIC_WAKEIP1,
+    };
+    unsafe {
+        ptr::write_volatile(wakeip, entry);
+        let sctlr = ptr::read_volatile(PFIC_SCTLR);
+        ptr::write_volatile(PFIC_SCTLR, sctlr | (1 << 5));
+    }
 }

--- a/src/pfic.rs
+++ b/src/pfic.rs
@@ -207,6 +207,14 @@ pub unsafe fn wfi_to_wfe(v: bool) {
 /// Read from `PFIC_SCTLR[23:16]` (`HART_ID` field). Only the LSB is
 /// meaningful — the upper bits of that field are reserved.
 ///
+/// On CH32H417 the standard RISC-V `mhartid` CSR is also valid and
+/// returns the same value (`0` on V3F, `1` on V5F — the WCH SDK's
+/// FreeRTOS port uses `mhartid` directly to pick per-hart `mtimecmp`
+/// registers). We read SCTLR instead because the PFIC-based hart id
+/// is documented as a QingKe-family convention and is portable to
+/// other dual-core QingKe parts that may not implement `mhartid` in
+/// the standard way.
+///
 /// `HART_ID` is documented in the QingKe V5 IP manual §8.1 and the
 /// CH32H417 RM §4.7.5.58, but is **not** defined in the QingKe
 /// V2 / V3 / V4 manuals, so this type is gated behind the

--- a/src/pfic.rs
+++ b/src/pfic.rs
@@ -48,11 +48,18 @@ const PFIC_IPRIOR0: *mut u8 = 0xE000E400 as *mut u8;
 /// 系统控制寄存器
 const PFIC_SCTLR: *mut u32 = 0xE000ED10 as *mut u32;
 
-/// Wake-up instruction pointer register for hart 0 (C0)
-/// 内核 C0 唤醒指令指针寄存器
+/// Wake-up instruction pointer register for hart 0 (C0).
+/// 内核 C0 唤醒指令指针寄存器.
+///
+/// Chip-specific multi-core extension — currently CH32H417 only.
+/// Not documented in any generic QingKe IP manual (V2/V3/V4/V5);
+/// see CH32H417 RM V1.7 §4.7.5.51.
+#[cfg(feature = "dual-core")]
 const PFIC_WAKEIP0: *mut u32 = 0xE000E720 as *mut u32;
-/// Wake-up instruction pointer register for hart 1 (C1)
-/// 内核 C1 唤醒指令指针寄存器
+/// Wake-up instruction pointer register for hart 1 (C1).
+/// 内核 C1 唤醒指令指针寄存器.
+/// See [`PFIC_WAKEIP0`] for caveats.
+#[cfg(feature = "dual-core")]
 const PFIC_WAKEIP1: *mut u32 = 0xE000E724 as *mut u32;
 
 #[inline]
@@ -195,12 +202,15 @@ pub unsafe fn wfi_to_wfe(v: bool) {
 
 /// Identifies the current QingKe hart in a multi-core PFIC.
 ///
-/// Read from `PFIC_SCTLR[23:16]` (HART_ID field). Only the LSB is
+/// Read from `PFIC_SCTLR[23:16]` (`HART_ID` field). Only the LSB is
 /// meaningful — the upper bits of that field are reserved.
 ///
-/// On single-core chips this always reads as [`HartId::C0`]. On
-/// dual-core chips such as CH32H417, the primary boot core (V3F) is
-/// `C0` and the secondary core (V5F) is `C1`.
+/// `HART_ID` is documented in the QingKe V5 IP manual §8.1 and the
+/// CH32H417 RM §4.7.5.58, but is **not** defined in the QingKe
+/// V2 / V3 / V4 manuals, so this type is gated behind the
+/// `dual-core` feature. On CH32H417 the primary boot core (V3F) is
+/// `C0` and the secondary (V5F) is `C1`.
+#[cfg(feature = "dual-core")]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
@@ -211,6 +221,7 @@ pub enum HartId {
     C1 = 1,
 }
 
+#[cfg(feature = "dual-core")]
 impl HartId {
     /// Read the current hart ID from `PFIC_SCTLR`.
     #[inline]
@@ -249,8 +260,9 @@ impl HartId {
 /// deep-sleep lock — then sets `PFIC_SCTLR.SENDEVENT` (bit 5) to
 /// deliver the wake event.
 ///
-/// On single-core chips this writes to a reserved register and has no
-/// observable effect.
+/// Gated behind `dual-core` because `WAKEIPx` are not documented in
+/// any generic QingKe IP manual — they are a chip-level multi-core
+/// extension currently known only on CH32H417.
 ///
 /// # Safety
 /// - `entry` must be 1KB-aligned (bottom 10 bits zero); debug builds
@@ -259,6 +271,7 @@ impl HartId {
 ///   reachable from the other hart's address space.
 /// - Typically called once by the primary hart (`C0`) during boot,
 ///   before any cross-core synchronization protocol begins.
+#[cfg(feature = "dual-core")]
 #[inline]
 pub unsafe fn wake_other_core(entry: u32) {
     debug_assert!(entry & 0x3FF == 0, "entry must be 1KB-aligned");

--- a/src/register.rs
+++ b/src/register.rs
@@ -2,5 +2,6 @@
 
 pub mod corecfgr;
 pub mod gintenr;
+pub mod inestcr;
 pub mod intsyscr;
 pub mod mtvec;

--- a/src/register.rs
+++ b/src/register.rs
@@ -2,6 +2,7 @@
 
 pub mod corecfgr;
 pub mod gintenr;
+#[cfg(feature = "_inestcr")]
 pub mod inestcr;
 pub mod intsyscr;
 pub mod mtvec;

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,8 +1,14 @@
 //! QingKe extended CSRs
 
+#[cfg(feature = "_v5")]
+pub mod cache_pmp_ovr;
+#[cfg(feature = "_v5")]
+pub mod cache_strtg_ctlr;
 pub mod corecfgr;
 pub mod gintenr;
 #[cfg(feature = "_inestcr")]
 pub mod inestcr;
 pub mod intsyscr;
 pub mod mtvec;
+#[cfg(feature = "_v5")]
+pub mod opcache_ctlr;

--- a/src/register/cache_pmp_ovr.rs
+++ b/src/register/cache_pmp_ovr.rs
@@ -1,0 +1,95 @@
+//! cache_pmp_ovr, ICache strategy PMP override register.
+//!
+//! QingKe V5-specific CSR at address 0xBC3. Provides a per-PMP-channel
+//! override of the global cacheability policy in
+//! [`cache_strtg_ctlr`](super::cache_strtg_ctlr): when an instruction
+//! fetch falls under a PMP channel, the matching bit here decides
+//! cacheability instead of the address-space policy in 0xBC2.
+//!
+//! **Availability**: only on cores with ICache hardware, gated
+//! behind the `_v5` feature.
+//!
+//! Field layout follows QingKe V5 IP manual §8.1.
+
+use bit_field::BitField;
+use core::arch::asm;
+
+/// PMP channel number used by [`CachePmpOvr`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum PmpChannel {
+    Pmp0 = 0,
+    Pmp1 = 4,
+    Pmp2 = 8,
+    Pmp3 = 12,
+}
+
+/// cache_pmp_ovr register view (CSR 0xBC3).
+#[derive(Clone, Copy, Debug)]
+pub struct CachePmpOvr {
+    bits: usize,
+}
+
+impl CachePmpOvr {
+    /// Whether instructions falling under the given PMP channel are
+    /// cacheable (`true`) or non-cacheable (`false`).
+    #[inline]
+    pub fn pmp_cacheable(&self, channel: PmpChannel) -> bool {
+        self.bits.get_bit(channel as usize)
+    }
+
+    /// Raw register bits.
+    #[inline]
+    pub fn bits(&self) -> usize {
+        self.bits
+    }
+}
+
+read_csr_as!(CachePmpOvr, 0xBC3);
+
+/// Overwrite the entire register.
+///
+/// # Safety
+/// Reserved bits should be kept at their reset values to remain
+/// forward-compatible.
+#[inline]
+pub unsafe fn write(bits: usize) {
+    unsafe { asm!("csrw 0xBC3, {0}", in(reg) bits) }
+}
+
+/// Set the listed bits via `csrs` (atomic set).
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn set_bits(mask: usize) {
+    unsafe { asm!("csrs 0xBC3, {0}", in(reg) mask) }
+}
+
+/// Clear the listed bits via `csrc` (atomic clear).
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn clear_bits(mask: usize) {
+    unsafe { asm!("csrc 0xBC3, {0}", in(reg) mask) }
+}
+
+/// Mark instructions covered by `channel` as cacheable.
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn enable_channel(channel: PmpChannel) {
+    unsafe { set_bits(1usize << channel as usize) }
+}
+
+/// Mark instructions covered by `channel` as non-cacheable.
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn disable_channel(channel: PmpChannel) {
+    unsafe { clear_bits(1usize << channel as usize) }
+}

--- a/src/register/cache_strtg_ctlr.rs
+++ b/src/register/cache_strtg_ctlr.rs
@@ -1,0 +1,128 @@
+//! cache_strtg_ctlr, instruction cache strategy control register.
+//!
+//! QingKe V5-specific CSR at address 0xBC2. Controls whether the
+//! instruction cache (ICache) is enabled at all, plus per-region
+//! cacheability for four standard address spaces.
+//!
+//! **Availability**: only on cores with ICache hardware, gated
+//! behind the `_v5` feature. V2 / V3 / V4 do not have this CSR.
+//!
+//! Field layout follows QingKe V5 IP manual §8.1.
+
+use bit_field::BitField;
+use core::arch::asm;
+
+/// Code region affected by a per-region cacheability bit in
+/// `cache_strtg_ctlr`. Address ranges are RISC-V 32-bit defaults.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum CacheRegion {
+    /// 0x00000000 - 0x1FFFFFFF (code Flash on CH32H417)
+    Code = 24,
+    /// 0x20000000 - 0x3FFFFFFF (SRAM, includes ITCM/DTCM on CH32H417)
+    Sram = 25,
+    /// 0x60000000 - 0x7FFFFFFF (external memory bank 0, FSMC)
+    Mem0 = 26,
+    /// 0x80000000 - 0x9FFFFFFF (external memory bank 1)
+    Mem1 = 27,
+}
+
+/// cache_strtg_ctlr register view (CSR 0xBC2).
+#[derive(Clone, Copy, Debug)]
+pub struct CacheStrtgCtlr {
+    bits: usize,
+}
+
+impl CacheStrtgCtlr {
+    /// Whether the given address-space region is currently allowed
+    /// to be cached.
+    #[inline]
+    pub fn region_cacheable(&self, region: CacheRegion) -> bool {
+        self.bits.get_bit(region as usize)
+    }
+
+    /// `ic_disable` (bit 1). When `true`, the entire ICache is
+    /// disabled regardless of per-region settings. Reset value is
+    /// `true` — software must clear this bit to start using ICache.
+    #[inline]
+    pub fn icache_disabled(&self) -> bool {
+        self.bits.get_bit(1)
+    }
+
+    /// Raw register bits.
+    #[inline]
+    pub fn bits(&self) -> usize {
+        self.bits
+    }
+}
+
+read_csr_as!(CacheStrtgCtlr, 0xBC2);
+
+/// Overwrite the entire register.
+///
+/// # Safety
+/// Caller must ensure the value is valid; reserved bits should be
+/// kept at their reset values to remain forward-compatible.
+#[inline]
+pub unsafe fn write(bits: usize) {
+    unsafe { asm!("csrw 0xBC2, {0}", in(reg) bits) }
+}
+
+/// Clear the listed bits via `csrc` (atomic clear).
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn clear_bits(mask: usize) {
+    unsafe { asm!("csrc 0xBC2, {0}", in(reg) mask) }
+}
+
+/// Set the listed bits via `csrs` (atomic set).
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn set_bits(mask: usize) {
+    unsafe { asm!("csrs 0xBC2, {0}", in(reg) mask) }
+}
+
+/// Enable the ICache globally by clearing `ic_disable` (bit 1).
+/// Per-region bits remain unchanged.
+///
+/// # Safety
+/// Caller must have set up the PMP and cache_pmp_ovr appropriately
+/// for any region they care about, and have invalidated the cache
+/// at least once before relying on its contents.
+#[inline]
+pub unsafe fn enable_icache() {
+    unsafe { clear_bits(1 << 1) }
+}
+
+/// Disable the ICache globally by setting `ic_disable` (bit 1).
+///
+/// # Safety
+/// See [`enable_icache`].
+#[inline]
+pub unsafe fn disable_icache() {
+    unsafe { set_bits(1 << 1) }
+}
+
+/// Enable caching for `region` while leaving other regions and the
+/// global `ic_disable` flag unchanged.
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn enable_region(region: CacheRegion) {
+    unsafe { set_bits(1usize << region as usize) }
+}
+
+/// Disable caching for `region`.
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn disable_region(region: CacheRegion) {
+    unsafe { clear_bits(1usize << region as usize) }
+}

--- a/src/register/corecfgr.rs
+++ b/src/register/corecfgr.rs
@@ -8,10 +8,10 @@ pub fn read() -> usize {
     ans
 }
 
-/// Write to corecfgr
+/// Write to corecfgr (full register write).
 #[inline]
 pub unsafe fn write(bits: usize) {
-    unsafe { asm!("csrs 0xBC0, {}", in(reg) bits) };
+    unsafe { asm!("csrw 0xBC0, {}", in(reg) bits) };
 }
 
 /// Write 0x1f to ??? (in EVT code)

--- a/src/register/inestcr.rs
+++ b/src/register/inestcr.rs
@@ -1,0 +1,152 @@
+//! inestcr, interrupt nest control register.
+//!
+//! QingKe-specific CSR at address 0xBC1. Controls the maximum
+//! interrupt nest depth and exposes nest status / overflow flags.
+//!
+//! Documented in QingKe V5 IP manual §8.1 (and used by V3F/V5F on
+//! CH32H417). V3 and earlier manuals don't describe this register
+//! in detail, but V3F's startup writes it the same way.
+
+use bit_field::BitField;
+use core::arch::asm;
+
+/// Maximum number of interrupt nesting levels.
+///
+/// Programmed into the low 3 bits of inestcr. On QingKe V3, only
+/// levels up to 2 are supported (`NestLevel::Disabled` / `Two`);
+/// values 3–8 are V5-only.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum NestLevel {
+    /// No interrupt nesting (one in-flight interrupt at a time).
+    Disabled = 0b000,
+    Two = 0b001,
+    Three = 0b010,
+    Four = 0b011,
+    Five = 0b100,
+    Six = 0b101,
+    Seven = 0b110,
+    /// Eight levels — the maximum, supported on QingKe V5.
+    Eight = 0b111,
+}
+
+impl NestLevel {
+    /// Decode the `NEST_STA` (status) field — a unary-style encoding
+    /// where each bit represents a "currently active at level N" flag.
+    /// Returns the count of consecutive low bits set, i.e. the
+    /// current nesting depth.
+    #[inline]
+    pub const fn from_status(bits: u8) -> u8 {
+        // Pattern: 0x00 → 0, 0x01 → 1, 0x03 → 2, 0x07 → 3, ...
+        // Equivalent to "count of trailing ones" plus 0.
+        bits.trailing_ones() as u8
+    }
+}
+
+/// inestcr register (CSR 0xBC1)
+#[derive(Clone, Copy, Debug)]
+pub struct Inestcr {
+    bits: usize,
+}
+
+impl Inestcr {
+    /// LSU NMI status flag. Set when the load/store unit raises a
+    /// non-maskable interrupt (typically a write-bus error). Write 1
+    /// to clear via [`clear_lsu_nmi`].
+    #[inline]
+    pub fn lsu_nmi_status(&self) -> bool {
+        self.bits.get_bit(31)
+    }
+
+    /// Nest overflow flag. Set when a level-2 ISR raises an
+    /// instruction exception or NMI causing the hardware stack to
+    /// overflow. Write 1 to clear via [`clear_nest_overflow`].
+    #[inline]
+    pub fn nest_overflow(&self) -> bool {
+        self.bits.get_bit(30)
+    }
+
+    /// Current nesting depth (0 .. 8). Encoded in `NEST_STA`
+    /// (bits 11:8) as trailing-ones.
+    #[inline]
+    pub fn nest_depth(&self) -> u8 {
+        NestLevel::from_status(self.bits.get_bits(8..=11) as u8)
+    }
+
+    /// Raw `NEST_STA` bits, unary-encoded.
+    #[inline]
+    pub fn nest_status_raw(&self) -> u8 {
+        self.bits.get_bits(8..=11) as u8
+    }
+
+    /// Configured maximum nest level.
+    #[inline]
+    pub fn nest_level(&self) -> NestLevel {
+        match self.bits.get_bits(0..=2) as u8 {
+            0b000 => NestLevel::Disabled,
+            0b001 => NestLevel::Two,
+            0b010 => NestLevel::Three,
+            0b011 => NestLevel::Four,
+            0b100 => NestLevel::Five,
+            0b101 => NestLevel::Six,
+            0b110 => NestLevel::Seven,
+            _ => NestLevel::Eight,
+        }
+    }
+
+    /// Raw register bits.
+    #[inline]
+    pub fn bits(&self) -> usize {
+        self.bits
+    }
+}
+
+read_csr_as!(Inestcr, 0xBC1);
+
+/// Overwrite the entire register.
+///
+/// Common values:
+/// - `0x01` on QingKe V3F (2-level nesting)
+/// - `0x07` on QingKe V5F (8-level nesting)
+///
+/// # Safety
+/// Caller must ensure the value matches the hardware capabilities of
+/// the running core. Writing reserved bits is allowed but may have
+/// undefined effects on future silicon revisions.
+#[inline]
+pub unsafe fn write(bits: usize) {
+    unsafe { asm!("csrw 0xBC1, {0}", in(reg) bits) }
+}
+
+/// Program `NEST_LVL` (max nesting depth) while preserving other
+/// bits.
+///
+/// # Safety
+/// See [`write`].
+#[inline]
+pub unsafe fn set_max_level(level: NestLevel) {
+    let mut v = read().bits;
+    v.set_bits(0..=2, level as usize);
+    unsafe { write(v) };
+}
+
+/// Write 1 to `NEST_OV` to clear the overflow latch.
+///
+/// # Safety
+/// Only meaningful while the overflow has been observed and the
+/// software is recovering. The other W1C bit (`LSU_NMI_STA`) is left
+/// untouched.
+#[inline]
+pub unsafe fn clear_nest_overflow() {
+    unsafe { asm!("csrw 0xBC1, {0}", in(reg) 1usize << 30) }
+}
+
+/// Write 1 to `LSU_NMI_STA` to clear the LSU-NMI latch.
+///
+/// # Safety
+/// See [`clear_nest_overflow`].
+#[inline]
+pub unsafe fn clear_lsu_nmi() {
+    unsafe { asm!("csrw 0xBC1, {0}", in(reg) 1usize << 31) }
+}

--- a/src/register/inestcr.rs
+++ b/src/register/inestcr.rs
@@ -3,9 +3,15 @@
 //! QingKe-specific CSR at address 0xBC1. Controls the maximum
 //! interrupt nest depth and exposes nest status / overflow flags.
 //!
-//! Documented in QingKe V5 IP manual §8.1 (and used by V3F/V5F on
-//! CH32H417). V3 and earlier manuals don't describe this register
-//! in detail, but V3F's startup writes it the same way.
+//! **Availability**: only on cores that gate the `_inestcr` feature
+//! in, currently `v3f` (CH32H417 V3F extension) and any `_v5`
+//! variant. The V2 / V3A / V3B / V4 generic QingKe IP manuals do
+//! not document this CSR and accessing 0xBC1 on those cores raises
+//! an illegal-instruction trap.
+//!
+//! Field layout follows QingKe V5 IP manual §8.1. The V3F variant
+//! supports the same layout but in practice only the lower nest
+//! levels (≤ 2) are useful given V3F's 2-level pipeline.
 
 use bit_field::BitField;
 use core::arch::asm;

--- a/src/register/opcache_ctlr.rs
+++ b/src/register/opcache_ctlr.rs
@@ -1,0 +1,84 @@
+//! opcache_ctlr, instruction cache operation control register.
+//!
+//! QingKe V5-specific write-only CSR at address 0xBD0. Each write
+//! performs a single ICache maintenance operation (currently only
+//! "invalidate"), selected by the `Opcode` field and parametrized
+//! by either a virtual address or a way/set index.
+//!
+//! **Availability**: only on cores with ICache hardware, gated
+//! behind the `_v5` feature.
+//!
+//! Field layout follows QingKe V5 IP manual §8.1.
+
+use core::arch::asm;
+
+/// Operation requested by a write to `opcache_ctlr`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(usize)]
+pub enum Opcode {
+    /// Invalidate one or more ICache lines, parametrized by
+    /// `vaddr` and the index-mode flag.
+    Invalidate = 0b00,
+}
+
+/// Whether `vaddr` is interpreted as a virtual address or a
+/// way/set index.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AddressMode {
+    /// `vaddr` is a virtual address; the cache line containing it
+    /// is selected.
+    Address,
+    /// `vaddr` encodes a way/set index pair; the entries are
+    /// selected by index.
+    Index,
+}
+
+impl AddressMode {
+    #[inline]
+    const fn bit(self) -> usize {
+        match self {
+            AddressMode::Address => 0,
+            AddressMode::Index => 1 << 2,
+        }
+    }
+}
+
+/// Issue an ICache maintenance operation.
+///
+/// The bottom 5 bits of `vaddr` are ignored by the hardware (line
+/// alignment); higher bits select the line in `Address` mode or the
+/// way/set in `Index` mode.
+///
+/// # Safety
+/// - Invalidating cache lines that the current core is about to
+///   execute may cause undefined behavior; typically called once
+///   during ICache initialization before enabling the cache, or
+///   after explicit instruction-memory rewrites.
+/// - Must only be called on cores that have ICache hardware.
+#[inline]
+pub unsafe fn issue(vaddr: usize, mode: AddressMode, op: Opcode) {
+    let bits = (vaddr & !0x1F) | mode.bit() | op as usize;
+    unsafe { asm!("csrw 0xBD0, {0}", in(reg) bits) }
+}
+
+/// Invalidate the entire ICache by issuing an index-mode
+/// invalidate sweep (the value `0x4` matches the CH32H417 SDK
+/// startup pattern).
+///
+/// # Safety
+/// See [`issue`].
+#[inline]
+pub unsafe fn invalidate_all() {
+    unsafe { issue(0, AddressMode::Index, Opcode::Invalidate) }
+}
+
+/// Invalidate the ICache line containing the given virtual address.
+///
+/// # Safety
+/// See [`issue`].
+#[inline]
+pub unsafe fn invalidate_addr(vaddr: usize) {
+    unsafe { issue(vaddr, AddressMode::Address, Opcode::Invalidate) }
+}


### PR DESCRIPTION
## Summary

Adds the QingKe pieces needed to bring up CH32H4 dual-core MCUs (V3F as boot hart 0, V5F as hart 1). Companion to ch32-rs/ch32-hal H4 work.

- `qingke-rt`: new `v3f` / `v5f` cargo features that select the right boot stub and ISR table per hart
- `qingke::pfic`: `HartId` + `wake_other_core` helpers (gated behind a dual-core feature so single-hart V3 / V4 builds keep their existing surface)
- `qingke::register`: typed wrapper for `inestcr` (interrupt-nest control), gated behind a `_inestcr` feature; \`setup\` now calls into it instead of a raw CSR write
- `qingke::register`: V5-only ICache CSRs `cache_strtg_ctlr` / `cache_pmp_ovr` / `opcache_ctlr` so H4's V5F hart can configure its icache
- `pfic::disable_vtf`: wrap the inner ptr ops in \`unsafe { }\` to satisfy Rust 2024's \`unsafe_op_in_unsafe_fn\` lint

## Test plan

- [x] \`cargo check --no-default-features --features _v3,unsafe-trust-wch-atomics\` clean
- [x] \`cargo check --no-default-features --features _v5,unsafe-trust-wch-atomics\` clean
- [x] Downstream ch32-hal H4 worktree (\`feat/h4-afio\`) consumes this branch via local \`[patch]\` and the \`examples/ch32h417\` blinky compiles
- [ ] Hardware bring-up on CH32H417EVT board (V3F boot, V5F core wake) — pending companion ch32-hal PR

## Notes

- The atomics guard (\`compile_error!\` unless \`unsafe-trust-wch-atomics\`) is still in place; we currently dodge it on H4 by using \`+forced-atomics\` in the example's target JSON. Verification plan for hardware atomics on V3F / V5F is documented in the ch32-hal-side \`docs/atomic-verification.md\`.