### PR TITLE
critical_section: use 0x88 mask on v4 to avoid INESTEN=1 wedge

### DIFF
--- a/src/critical_section_impl.rs
+++ b/src/critical_section_impl.rs
@@ -13,6 +13,14 @@ unsafe impl Impl for SingleHartCriticalSection {
                 let mut mstatus: usize;
                 unsafe { core::arch::asm!("csrrci {}, mstatus, 0b1000", out(reg) mstatus) };
                 (mstatus & 0b1000) != 0
+            } else if #[cfg(feature = "v4")] {
+                // V4: mask MIE+MPIE together (0x88), matching openwch SDK
+                // https://github.com/openwch/ch32v20x/blob/main/EVT/EXAM/SRC/Core/core_riscv.h.
+                // Fixes silent MIE-stuck-at-0 wedge when critical_section is
+                // invoked inside an ISR body with INTSYSCR.INESTEN=1.
+                let prior: usize;
+                unsafe { core::arch::asm!("csrrc {}, 0x800, {}", out(reg) prior, in(reg) 0x88usize) };
+                (prior & 0x8) != 0
             } else {
                 // Other QingKe cores have gintenr register
                 use crate::register::gintenr;
@@ -27,6 +35,8 @@ unsafe impl Impl for SingleHartCriticalSection {
             cfg_if::cfg_if! {
                 if #[cfg(any(feature = "v2", feature = "v3a"))] {
                     unsafe { core::arch::asm!("csrsi mstatus, 0b1000") };
+                } else if #[cfg(feature = "v4")] {
+                    unsafe { core::arch::asm!("csrs 0x800, {}", in(reg) 0x88usize) };
                 } else {
                     use crate::register::gintenr;
                     unsafe { gintenr::set_enable() };


### PR DESCRIPTION
## Summary

V4 cores (CH32V20x) can wedge with `MIE` stuck at 0 in user code when `critical_section::with` runs inside an ISR body while `INTSYSCR.INESTEN=1`. The standard 0x8-mask path touches `MIE` only, leaving an `MIE=0` / `MPIE=1` mismatch that V4's nested-interrupt machinery doesn't recover from — `MIE=0` eventually propagates outward through nested `mret`s, all async IRQs end up masked indefinitely, and the system silently stalls (no sync exception, ISR enter/exit counts balanced).

This PR routes V4 through its own cfg arm using the 0x88 mask (`MIE` + `MPIE` together via `gintenr`), matching openwch's `__disable_irq` / `__enable_irq` pattern for V20x [1] and preserving the implicit "MIE and MPIE move together" invariant V4 expects inside an ISR body.

## Why openwch's C SDK doesn't hit this

C code without an embassy-style task runtime essentially never invokes a `critical_section`-style acquire from inside an ISR body, so the bad path doesn't fire. openwch's `__disable_irq` / `__enable_irq` happen to use the 0x88 mask anyway — likely accidental robustness inherited from older WCH conventions, no comment explains it.

## Verification

Reproduced on CH32V203C8T6 with embassy + nested PFIC (`INTSYSCR=0b0111`, HWSTKEN + INESTEN + PMTCFG=01): wedge fires within a few thousand IRQ-driven round-trips on the standard 0x8 mask; the 0x88 mask cleared tens of thousands without recurrence. `PMTCFG=0` (no preempt classes possible) still wedges, so the trigger is the `INESTEN` bit *enabling the nesting machinery*, not actual L2-preempt firings.

## References

- V4 manual §2.3 (MIE not cleared on non-deepest trap entry) and §8.3 (gintenr is the bit-level alias of mstatus)
- [1] openwch CH32V20X SDK [`core_riscv.h`](https://github.com/openwch/ch32v20x/blob/main/EVT/EXAM/SRC/Core/core_riscv.h#L132)